### PR TITLE
[BUGFIX] Use new identifier after move to extension while performUpdate.

### DIFF
--- a/Classes/Updates/DbalAndAdodbExtractionUpdate.php
+++ b/Classes/Updates/DbalAndAdodbExtractionUpdate.php
@@ -101,10 +101,11 @@ class DbalAndAdodbExtractionUpdate extends AbstractDownloadExtensionUpdate
     public function performUpdate(array &$databaseQueries, &$customMessage)
     {
         $requestParams = GeneralUtility::_GP('install');
-        if (!isset($requestParams['values']['TYPO3\CMS\Install\Updates\DbalAndAdodbExtractionUpdate']['install'])) {
+        $identifier = get_class($this);
+        if (!isset($requestParams['values'][$identifier]['install'])) {
             return false;
         }
-        $install = (int)$requestParams['values']['TYPO3\CMS\Install\Updates\DbalAndAdodbExtractionUpdate']['install'];
+        $install = (int)$requestParams['values'][$identifier]['install'];
 
         if ($install === 1) {
             // user decided to install extensions, install and mark wizard as done


### PR DESCRIPTION
At the moment the UpgradeWizard can't be run as we do not find our parameters.

BTW: For the function "getUserInput" we create an identifier but for the function checkUserInput (or performUpdate) we do not, so the update script needs to handle this by itself. Maybe UpgradeWizardsService needs changes in the future.