### PR TITLE
do not free the SQL result in error case

### DIFF
--- a/Classes/Database/DatabaseConnection.php
+++ b/Classes/Database/DatabaseConnection.php
@@ -379,7 +379,6 @@ class DatabaseConnection
         $this->logDeprecation();
         $res = $this->exec_SELECTquery($select_fields, $from_table, $where_clause, $groupBy, $orderBy, $limit);
         if ($this->sql_error()) {
-            $this->sql_free_result($res);
             return null;
         }
         $output = [];


### PR DESCRIPTION
After executing a wrong SQL message I get a PHP error:

    Invalid database result detected: function TYPO3\CMS\Core\Database\DatabaseConnection->sql_free_result

see 
https://forge.typo3.org/issues/87557#change-394127