### PR TITLE
Replace call to GeneralUtility::logDeprecatedFunction() with `trigger_error` in v11

### DIFF
--- a/Classes/Database/PreparedStatement.php
+++ b/Classes/Database/PreparedStatement.php
@@ -167,7 +167,11 @@ class PreparedStatement
      */
     public function __construct($query, $table, array $precompiledQueryParts = [])
     {
-        GeneralUtility::logDeprecatedFunction();
+        if (method_exists('GeneralUtility', 'logDeprecatedFunction')) {
+            GeneralUtility::logDeprecatedFunction();
+        } else {
+            trigger_error('PreparedStatement from EXT:typo3db_legacy is marked as deprecated, use Doctrine DBAL as it does PreparedStatements built-in', E_USER_DEPRECATED);
+        }
         $this->query = $query;
         $this->precompiledQueryParts = $precompiledQueryParts;
         $this->table = $table;


### PR DESCRIPTION
Replace call to method `GeneralUtility::logDeprecatedFunction` in`PreparedStatement::__construct()` with `trigger_error` to avoid failure on v11.

Fixes: https://github.com/FriendsOfTYPO3/typo3db_legacy/issues/26