### PR TITLE
Make it possible to set connection driverOptions (eg MYSQLI_CLIENT_SSL)

### DIFF
--- a/Classes/Database/DatabaseConnection.php
+++ b/Classes/Database/DatabaseConnection.php
@@ -1298,6 +1298,7 @@ class DatabaseConnection
             'user' => $this->databaseUsername,
             'password' => $this->databaseUserPassword,
             'charset' => $this->connectionCharset,
+            'driverOptions' => $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['driverOptions'] ?? [],
         ]);
 
         // Mimic the previous behavior of returning false on connection errors

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -45,8 +45,8 @@ call_user_func(function () {
     }
 
     $isDatabaseHostLocalHost = in_array($databaseHost, ['localhost', '127.0.0.1', '::1'], true);
-    if (isset($GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['driverOptions'])
-        && $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['driverOptions'] & MYSQLI_CLIENT_COMPRESS
+    if (isset($GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['driverOptions']['flags'])
+        && $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['driverOptions']['flags'] & MYSQLI_CLIENT_COMPRESS
         && !$isDatabaseHostLocalHost
     ) {
         $databaseConnection->setConnectionCompression(true);


### PR DESCRIPTION
I would like to set the MYSQLI_CLIENT_SSL driverOptions. This requires a change in the connection.
With PHP 7.4 this was fine ... after updating to 8.2 i've got a type error in the ext_localconf.php (int vs array)

`$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['driverOptions']['flags'] = MYSQLI_CLIENT_SSL;`

This patch works for me.